### PR TITLE
[CH7-5] Windows에서 Base64 인코딩 수정

### DIFF
--- a/.github/workflows/moviereminder-android-cd.yml
+++ b/.github/workflows/moviereminder-android-cd.yml
@@ -27,12 +27,12 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           working-directory: ${{ env.PROJECT_PATH }}
       - name: Generate keystore
-        run: echo $ANDROID_RELEASE_KEYSTORE | base64 -d > ./android/app/my-upload-key.keystore
+        run: echo "$ANDROID_RELEASE_KEYSTORE" | base64 -d > ./android/app/my-upload-key.keystore
         env:
           ANDROID_RELEASE_KEYSTORE: ${{ secrets.ANDROID_RELEASE_KEYSTORE }}
         working-directory: ${{ env.PROJECT_PATH }}
       - name: Generate playstore service account
-        run: mkdir -p android/key && echo $PLAYSTORE_SERVICE_ACCOUNT | base64 -d > ./android/key/pc-api-7049181514897908329-469-71e75a96347d.json
+        run: mkdir -p android/key && echo "$PLAYSTORE_SERVICE_ACCOUNT" | base64 -d > ./android/key/pc-api-7049181514897908329-469-71e75a96347d.json
         env:
           PLAYSTORE_SERVICE_ACCOUNT: ${{ secrets.PLAYSTORE_SERVICE_ACCOUNT }}
         working-directory: ${{ env.PROJECT_PATH }}


### PR DESCRIPTION
### 원인
* 윈도우에서 `certutil -encode` 명령어로 파일을 인코딩시에 줄바꿈이 포함됩니다.
* 따라서, `echo $ANDROID_RELEASE_KEYSTORE | base64 -d > ./android/app/my-upload-key.keystore` 명령어를 Github Actions에서 실행시에 invalid input 에러가 발생합니다.

### 수정 방법
* 배포 스크립트를 해당 PR 처럼 수정해서 에러를 고칠 수 있습니다.
* 참고 답변: https://unix.stackexchange.com/a/699115

### 참고 사항
* 윈도우에서 `certutil -encode` 명령어로 인코딩 시에 인코딩 결과가 다음 처럼 생성됩니다.
```
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```
* Github actions secret에 등록 시, `-----BEGIN CERTIFICATE-----`와 `-----END CERTIFICATE-----`라인은 제외한 `...` 부분만 등록하셔야 합니다.